### PR TITLE
Sync node model and connection freeze state

### DIFF
--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -8,6 +8,8 @@
 #include "DefaultNodePainter.hpp"
 #include "DefaultVerticalNodeGeometry.hpp"
 #include "NodeGraphicsObject.hpp"
+#include "DataFlowGraphModel.hpp"
+#include "NodeDelegateModel.hpp"
 
 #include <QUndoStack>
 
@@ -253,6 +255,13 @@ QMenu *BasicGraphicsScene::createFreezeMenu(QPointF const scenePos)
                             }
                         }
                     }
+
+                    if (auto *dfModel = dynamic_cast<DataFlowGraphModel *>(&graphModel())) {
+                        if (auto *delegate =
+                                dfModel->delegateModel<NodeDelegateModel>(n->nodeId())) {
+                            delegate->setFrozenState(true);
+                        }
+                    }
                 }
             }
 
@@ -277,6 +286,13 @@ QMenu *BasicGraphicsScene::createFreezeMenu(QPointF const scenePos)
                                 cgo->connectionState().setFrozen(false);
                                 cgo->update();
                             }
+                        }
+                    }
+
+                    if (auto *dfModel = dynamic_cast<DataFlowGraphModel *>(&graphModel())) {
+                        if (auto *delegate =
+                                dfModel->delegateModel<NodeDelegateModel>(n->nodeId())) {
+                            delegate->setFrozenState(false);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- keep NodeDelegateModel's frozen flag in sync with ConnectionState when freezing or unfreezing via the context menu
- include DataFlowGraphModel and NodeDelegateModel for access to delegate model API

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT"; file DOWNLOAD cannot compute hash on failed download)*

------
https://chatgpt.com/codex/tasks/task_e_689b63b73fbc8331b0944a72991b7cf6